### PR TITLE
Allow non-unique config sections

### DIFF
--- a/config.go
+++ b/config.go
@@ -318,8 +318,9 @@ func parseRoutinesConfig(routines *[]RoutineSpawner, cfg *ini.File, sectionName 
 // ParseConfig takes the path of a configuration file and parses it into Configuration
 func ParseConfig(path string) (*Configuration, error) {
 	iniOpt := ini.LoadOptions{
-		Insensitive:  true,
-		AllowShadows: true,
+		Insensitive:            true,
+		AllowShadows:           true,
+		AllowNonUniqueSections: true,
 	}
 
 	cfg, err := ini.LoadSources(iniOpt, path)


### PR DESCRIPTION
I wanted multiple TCPServerTunnels, but wireproxy wasn't parsing the ini in a way that allows this. With this change, I am able to run multiple TCPServerTunnels in a single wireproxy process.

Draft because I haven't tested out the implications of allowing non-unique sections on anything else. For `Peer` it should probably be alllowed, for `Interface` probably not