### PR TITLE
send a keepalive after establishing a connection

### DIFF
--- a/wireguard.go
+++ b/wireguard.go
@@ -74,6 +74,9 @@ func StartWireguard(conf *DeviceConfig) (*VirtualTun, error) {
 		return nil, err
 	}
 
+	// Sending a keepalive directly after connecting makes the wireproxy reachable instantly
+	dev.SendKeepalivesToPeersWithCurrentKeypair()
+
 	return &VirtualTun{
 		tnet:      tnet,
 		systemDNS: len(setting.dns) == 0,


### PR DESCRIPTION
This PR adds a call to send a keepalive right after the Wireguard connection was established.
This leads to the proxy being available on the Wireguard network right away, instead of just after the first keepalive package was sent / the first byte is sent from the proxy.

This is especially important for using the proxy without opening a SOCKS proxy, as this would otherwise not send any traffic from the proxy and thus it would not be available on the Wireguard network.

This should close https://github.com/octeep/wireproxy/issues/38