### PR TITLE
Stdio tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Target = play.cubecraft.net:25565
 ListenPort = 3422
 Target = localhost:25545
 
+# STDIOTunnel is a tunnel connecting the standard input and output of the wireproxy
+# process to the specified TCP target via wireguard.
+# This is especially useful to use wireproxy as a ProxyCommand parameter in openssh
+# For example:
+#    ssh -o ProxyCommand='wireproxy -c myconfig.conf' ssh.myserver.net
+# Flow:
+# Piped command -->(wireguard)--> ssh.myserver.net:22
+[STDIOTunnel]
+Target = ssh.myserver.net:22
+
 # Socks5 creates a socks5 proxy on your LAN, and all traffic would be routed via wireguard.
 [Socks5]
 BindAddress = 127.0.0.1:25344

--- a/cmd/wireproxy/main.go
+++ b/cmd/wireproxy/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/akamensky/argparse"
 	"github.com/octeep/wireproxy"
@@ -116,6 +117,10 @@ func main() {
 		return
 	}
 
+	// Wireguard doesn't allow configuring which FD to use for logging
+	// https://github.com/WireGuard/wireguard-go/blob/master/device/logger.go#L39
+	// so redirect STDOUT to STDERR, we don't want to print anything to STDOUT anyways
+	os.Stdout = os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
 	logLevel := device.LogLevelVerbose
 	if *silent {
 		logLevel = device.LogLevelSilent

--- a/config.go
+++ b/config.go
@@ -34,6 +34,10 @@ type TCPClientTunnelConfig struct {
 	Target      string
 }
 
+type STDIOTunnelConfig struct {
+	Target      string
+}
+
 type TCPServerTunnelConfig struct {
 	ListenPort int
 	Target     string
@@ -300,6 +304,17 @@ func parseTCPClientTunnelConfig(section *ini.Section) (RoutineSpawner, error) {
 	return config, nil
 }
 
+func parseSTDIOTunnelConfig(section *ini.Section) (RoutineSpawner, error) {
+	config := &STDIOTunnelConfig{}
+	targetSection, err := parseString(section, "Target")
+	if err != nil {
+		return nil, err
+	}
+	config.Target = targetSection
+
+	return config, nil
+}
+
 func parseTCPServerTunnelConfig(section *ini.Section) (RoutineSpawner, error) {
 	config := &TCPServerTunnelConfig{}
 
@@ -414,6 +429,11 @@ func ParseConfig(path string) (*Configuration, error) {
 	var routinesSpawners []RoutineSpawner
 
 	err = parseRoutinesConfig(&routinesSpawners, cfg, "TCPClientTunnel", parseTCPClientTunnelConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	err = parseRoutinesConfig(&routinesSpawners, cfg, "STDIOTunnel", parseSTDIOTunnelConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allows wireproxy to be used directly as a ProxyCommand in openssh.