### PR TITLE
Version Update on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ make
 # Install
 
 ```bash
-go install github.com/windtf/wireproxy/cmd/wireproxy@v1.0.9 # or @latest
+go install github.com/windtf/wireproxy/cmd/wireproxy@v1.1.2 # or @latest
 ```
 
 # Use with VPN


### PR DESCRIPTION
Related to: https://github.com/windtf/wireproxy/issues/202

I guess at the version v1.0.9 the go mod was defined as `module github.com/pufferffish/wireproxy`

Updating the README should make it more clear and avoid such issues in the future.