### PR TITLE
Landlock causes HTTPs permission issues

### DIFF
--- a/cmd/wireproxy/main.go
+++ b/cmd/wireproxy/main.go
@@ -68,7 +68,25 @@ func configFilePath() (string, bool) {
 	return "", false
 }
 
-func lock(stage string) {
+// get the file paths for TLS cert and key from the config
+func tlsFilePaths(routines []wireproxy.RoutineSpawner) []string {
+	var paths []string
+	for _, routine := range routines {
+		http, ok := routine.(*wireproxy.HTTPConfig)
+		if !ok {
+			continue
+		}
+		if http.CertFile != "" {
+			paths = append(paths, http.CertFile)
+		}
+		if http.KeyFile != "" {
+			paths = append(paths, http.KeyFile)
+		}
+	}
+	return paths
+}
+
+func lock(stage string, roFilles ...string) {
 	switch stage {
 	case "boot":
 		exePath := executablePath()
@@ -93,7 +111,11 @@ func lock(stage string) {
 		pledgeOrPanic("stdio inet dns")
 		// Linux
 		net.DefaultResolver.PreferGo = true // needed to lock down dependencies
-		panicIfError(landlock.V1.BestEffort().RestrictPaths(
+
+		// We need to define the static rules beforehand,
+		// so we can add the provided dynamic rules
+
+		rules := []landlock.Rule{
 			landlock.ROFiles("/etc/resolv.conf").IgnoreIfMissing(),
 			landlock.ROFiles("/dev/fd").IgnoreIfMissing(),
 			landlock.ROFiles("/dev/zero").IgnoreIfMissing(),
@@ -112,7 +134,16 @@ func lock(stage string) {
 			landlock.RWFiles("/dev/null").IgnoreIfMissing(),
 			landlock.RWFiles("/dev/full").IgnoreIfMissing(),
 			landlock.RWFiles("/proc/self/fd").IgnoreIfMissing(),
-		))
+		}
+
+		if len(roFilles) > 0 {
+			for _, file := range roFilles {
+				rules = append(rules, landlock.ROFiles(file).IgnoreIfMissing())
+			}
+		}
+
+		panicIfError(landlock.V1.BestEffort().RestrictPaths(rules...))
+
 	default:
 		panic("invalid stage")
 	}
@@ -246,7 +277,7 @@ func main() {
 		logLevel = device.LogLevelSilent
 	}
 
-	lock("ready")
+	lock("ready", tlsFilePaths(conf.Routines)...)
 
 	tun, err := wireproxy.StartWireguard(conf, logLevel)
 	if err != nil {


### PR DESCRIPTION
Hello,

When building a docker image from the latest main branch, a permission error occurs when providing the main HTTPs certificate and private key via the config file. This is due to the fact that on linux machines, landlock rules are applied before the HTTP server loads the necessary files, which are not included in the rule list. This can be reporduced by creating a linux docker image, enabiling the HTTP proxy, and providing `CertFile` and `KeyFile` via the config file. 

This fix adds the files to the rulelist, allowing the HTTP server to correctly load them. An alternative approach would be to load the files into the HTTP server before preforming the lock, but I wanted to keep the current order in case there is something I am missing.

This fix enables the correct behavior on my end. Please let me know if there any any issues, I would be happy to fix them.

Thanks!